### PR TITLE
Assorted changes to peripherals

### DIFF
--- a/isa/src/fmt.rs
+++ b/isa/src/fmt.rs
@@ -1,27 +1,7 @@
 //! Format impls. (TODO)
 
-use super::isa::{Instruction, Reg};
+use super::isa::Instruction;
 use core::fmt::{self, Display};
-
-impl Display for Reg {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Reg::*;
-        write!(
-            fmt,
-            "R{}",
-            match self {
-                R0 => '0',
-                R1 => '1',
-                R2 => '2',
-                R3 => '3',
-                R4 => '4',
-                R5 => '5',
-                R6 => '6',
-                R7 => '7',
-            }
-        )
-    }
-}
 
 impl Display for Instruction {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/isa/src/isa.rs
+++ b/isa/src/isa.rs
@@ -1,12 +1,16 @@
 use super::{SignedWord, Word};
 
+use lc3_macros::DisplayUsingDebug;
+
 use core::cmp::Ordering;
 use core::convert::{TryFrom, TryInto};
 use core::ops::Range;
+
 use serde::{Deserialize, Serialize};
 
 #[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(DisplayUsingDebug)]
 pub enum PriorityLevel { PL0, PL1, PL2, PL3, PL4, PL5, PL6, PL7 }
 
 // TODO: ditch the next four things once the macro is written:
@@ -82,6 +86,7 @@ impl Ord for PriorityLevel {
 
 #[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(DisplayUsingDebug)]
 pub enum Reg { R0, R1, R2, R3, R4, R5, R6, R7 }
 
 // TODO: ditch these next four things once we write the macro...

--- a/isa/src/isa.rs
+++ b/isa/src/isa.rs
@@ -6,7 +6,7 @@ use core::ops::Range;
 use serde::{Deserialize, Serialize};
 
 #[rustfmt::skip]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PriorityLevel { PL0, PL1, PL2, PL3, PL4, PL5, PL6, PL7 }
 
 // TODO: ditch the next four things once the macro is written:
@@ -81,8 +81,7 @@ impl Ord for PriorityLevel {
 }
 
 #[rustfmt::skip]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Reg { R0, R1, R2, R3, R4, R5, R6, R7 }
 
 // TODO: ditch these next four things once we write the macro...
@@ -214,7 +213,7 @@ impl Reg {
 type Sw = SignedWord;
 
 #[rustfmt::skip]
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Copy, Clone, Hash, Serialize, Deserialize)]
 // TODO: docs!
 // Give the full name of the instruction, the pseudo code, whether it sets
 // condition codes, the bit format, and some examples.

--- a/isa/src/misc.rs
+++ b/isa/src/misc.rs
@@ -298,10 +298,11 @@ pub fn __() -> () {}
 pub mod util {
     /// Associated types and other weird bits for the LC-3 ISA.
     use crate::{Addr, Word, ADDR_SPACE_SIZE_IN_WORDS};
+
     use core::ops::{Deref, DerefMut};
 
     // Newtype
-    #[derive(Clone)]
+    #[derive(Clone)] // TODO: impl Debug + PartialEq/Eq + Ser/De + Hash
     pub struct MemoryDump(pub [Word; ADDR_SPACE_SIZE_IN_WORDS]);
     impl Deref for MemoryDump {
         type Target = [Word; ADDR_SPACE_SIZE_IN_WORDS];
@@ -359,7 +360,7 @@ pub mod util {
     }
 
     // Newtype
-    #[derive(Clone)]
+    #[derive(Clone)] // TODO: impl Debug + PartialEq/Eq + Ser/De + Hash
     pub struct AssembledProgram(pub [(Word, bool); ADDR_SPACE_SIZE_IN_WORDS]);
     impl Deref for AssembledProgram {
         type Target = AssembledProgramInner;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -101,3 +101,25 @@ pub fn create_label(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
     proc_macro::TokenStream::from(quote!(let #ident: Addr = #tree;))
 }
+
+use syn::DeriveInput;
+
+// TODO: this should eventually become the macro we've waiting for, for ordered enums
+// with variants that have no associated data. It should bestow upon such enums:
+//  - an associated const specifying the number of enums
+//  - optionally, to and from impls for the variant's number (i.e. 0 -> R0, R0 -> 0)
+//  - optionally, an array type w/Deref+Index impls
+//  - a display impl (indep of Debug? not sure)
+#[proc_macro_derive(DisplayUsingDebug)]
+pub fn derive_display_from_debug(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let item = parse_macro_input!(item as DeriveInput);
+    let ty_name = item.ident;
+
+    quote! (
+        impl core::fmt::Display for #ty_name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                <Self as core::fmt::Debug>::fmt(self, f)
+            }
+        }
+    ).into()
+}

--- a/traits/src/error.rs
+++ b/traits/src/error.rs
@@ -18,7 +18,7 @@ use serde::{Serialize, Deserialize};
 //    + I'm warming to this idea, actually. The underlying infrastructure (peripherals, control) agree on a set of errors; how those
 //      errors make their way into LC-3 land is up to the interpreter. It's literally a matter of mapping these Errors into whatever.
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Error {
     InvalidGpioWrite(GpioWriteError),
     InvalidGpioWrites(GpioWriteErrors),
@@ -67,7 +67,7 @@ err!(GpioWriteError, Error::InvalidGpioWrite);
 ///
 /// TBD on whether this is impl-defined.
 /// Another thing to consider is that we may want different modes? Permissive and strict or something. Or maybe not.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ErrorHandlingStrategy {
     DefaultValue(Word),
     Silent,

--- a/traits/src/peripherals/adc.rs
+++ b/traits/src/peripherals/adc.rs
@@ -10,15 +10,15 @@ use serde::{Deserialize, Serialize};
 #[rustfmt::skip]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[derive(Serialize, Deserialize)]
-pub enum AdcPin { A0, A1, A2, A3 } // TODO: bump to 6
+pub enum AdcPin { A0, A1, A2, A3, A4, A5 }
 
 impl AdcPin {
-    pub const NUM_PINS: usize = 4;
+    pub const NUM_PINS: usize = 6;
 }
 
 pub const ADC_PINS: AdcPinArr<AdcPin> = {
     use AdcPin::*;
-    AdcPinArr([A0, A1, A2, A3])
+    AdcPinArr([A0, A1, A2, A3, A4, A5])
 }; // TODO: once we get the derive macro, get rid of this.
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -36,6 +36,8 @@ impl From<AdcPin> for usize {
             A1 => 1,
             A2 => 2,
             A3 => 3,
+            A4 => 4,
+            A5 => 5,
         }
     }
 }

--- a/traits/src/peripherals/adc.rs
+++ b/traits/src/peripherals/adc.rs
@@ -8,8 +8,7 @@ use serde::{Deserialize, Serialize};
 // TODO: Add Errors
 
 #[rustfmt::skip]
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum AdcPin { A0, A1, A2, A3, A4, A5 }
 
 impl AdcPin {
@@ -21,8 +20,7 @@ pub const ADC_PINS: AdcPinArr<AdcPin> = {
     AdcPinArr([A0, A1, A2, A3, A4, A5])
 }; // TODO: once we get the derive macro, get rid of this.
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AdcState {
     Enabled,
     Disabled,
@@ -42,8 +40,7 @@ impl From<AdcPin> for usize {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AdcPinArr<T>(pub [T; AdcPin::NUM_PINS]);
 
 // Once const fn is more stable:
@@ -105,13 +102,12 @@ pub trait Adc: Default {
 
 }}
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AdcMiscError;
 
 pub type AdcStateMismatch = (AdcPin, AdcState);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AdcReadError(pub AdcStateMismatch);
 
 // TODO: Into Error stuff (see Gpio)

--- a/traits/src/peripherals/adc.rs
+++ b/traits/src/peripherals/adc.rs
@@ -1,14 +1,17 @@
 //! [`Adc` trait](Adc) and associated types.
 
 use crate::peripheral_trait;
-use core::ops::{Deref, Index, IndexMut};
 
+use lc3_macros::DisplayUsingDebug;
+
+use core::ops::{Deref, Index, IndexMut};
 
 use serde::{Deserialize, Serialize};
 // TODO: Add Errors
 
 #[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(DisplayUsingDebug)]
 pub enum AdcPin { A0, A1, A2, A3, A4, A5 }
 
 impl AdcPin {

--- a/traits/src/peripherals/clock.rs
+++ b/traits/src/peripherals/clock.rs
@@ -1,6 +1,7 @@
 //! [`Clock` trait](Clock).
 
 use crate::peripheral_trait;
+
 use lc3_isa::Word;
 
 // Just 1 Clock! (millisecond units)

--- a/traits/src/peripherals/gpio.rs
+++ b/traits/src/peripherals/gpio.rs
@@ -51,7 +51,7 @@ impl From<GpioPin> for usize {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GpioState {
     Input,
     Output,
@@ -65,7 +65,7 @@ pub enum GpioState {
     Disabled,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioPinArr<T>(pub [T; GpioPin::NUM_PINS]);
 
 // For when we have const functions:
@@ -106,23 +106,23 @@ impl<T> IndexMut<GpioPin> for GpioPinArr<T> {
 
 // pub type GpioPinArr<T> = [T; GpioPin::NUM_PINS];
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioMiscError;
 
 type GpioStateMismatch = (GpioPin, GpioState);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioReadError(pub GpioStateMismatch);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioWriteError(pub GpioStateMismatch);
 
 pub type GpioStateMismatches = GpioPinArr<Option<GpioStateMismatch>>; // [Option<GpioStateMismatch>; NUM_GPIO_PINS as usize];
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioReadErrors(pub GpioStateMismatches);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GpioWriteErrors(pub GpioStateMismatches);
 
 // #[derive(Copy, Clone)]

--- a/traits/src/peripherals/gpio.rs
+++ b/traits/src/peripherals/gpio.rs
@@ -1,9 +1,11 @@
 //! [`Gpio` trait](Gpio) and friends.
 
+use crate::peripheral_trait;
+
+use lc3_macros::DisplayUsingDebug;
+
 use core::convert::TryFrom;
 use core::ops::{Deref, Index, IndexMut};
-
-use crate::peripheral_trait;
 use core::sync::atomic::AtomicBool;
 
 use serde::{Deserialize, Serialize};
@@ -22,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 #[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(DisplayUsingDebug)]
 pub enum GpioPin { G0, G1, G2, G3, G4, G5, G6, G7 }
 
 impl GpioPin {

--- a/traits/src/peripherals/input.rs
+++ b/traits/src/peripherals/input.rs
@@ -3,6 +3,8 @@ use crate::peripheral_trait;
 
 use core::sync::atomic::AtomicBool;
 
+use serde::{Deserialize, Serialize};
+
 peripheral_trait! {input,
 pub trait Input<'a>: Default {
     // Warning! This is stateful!! It marks the current data as read.
@@ -24,7 +26,7 @@ pub trait Input<'a>: Default {
     fn interrupts_enabled(&self) -> bool;
 }}
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct InputError;
 
 // TODO: roll this into the macro

--- a/traits/src/peripherals/output.rs
+++ b/traits/src/peripherals/output.rs
@@ -3,6 +3,8 @@ use crate::peripheral_trait;
 
 use core::sync::atomic::AtomicBool;
 
+use serde::{Deserialize, Serialize};
+
 peripheral_trait! {output,
 pub trait Output<'a>: Default {
     fn write_data(&mut self, c: u8) -> Result<(), OutputError>;
@@ -19,7 +21,7 @@ pub trait Output<'a>: Default {
     fn interrupts_enabled(&self) -> bool;
 }}
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OutputError;
 
 using_std! {

--- a/traits/src/peripherals/pwm.rs
+++ b/traits/src/peripherals/pwm.rs
@@ -1,15 +1,18 @@
 //! [`Pwm` trait](Pwm) and helpers.
 
 use crate::peripheral_trait;
+
+use lc3_macros::DisplayUsingDebug;
+
 use core::num::NonZeroU8;
 use core::ops::{Deref, Index, IndexMut};
-
 
 use serde::{Deserialize, Serialize};
 // TODO: Switch to enum for pins
 // TODO: Add Errors
 #[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(DisplayUsingDebug)]
 pub enum PwmPin { P0, P1 }
 
 // TODO: remove once the derive macro happens...

--- a/traits/src/peripherals/pwm.rs
+++ b/traits/src/peripherals/pwm.rs
@@ -9,8 +9,7 @@ use serde::{Deserialize, Serialize};
 // TODO: Switch to enum for pins
 // TODO: Add Errors
 #[rustfmt::skip]
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum PwmPin { P0, P1 }
 
 // TODO: remove once the derive macro happens...
@@ -33,15 +32,13 @@ pub const PWM_PINS: PwmPinArr<PwmPin> = {
     PwmPinArr([P0, P1])
 }; // TODO: save us, derive macro
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PwmState {
     Enabled(NonZeroU8),
     Disabled,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PwmPinArr<T>(pub [T; PwmPin::NUM_PINS]);
 
 // Once const fn is more stable:
@@ -74,10 +71,10 @@ impl<T> IndexMut<PwmPin> for PwmPinArr<T> {
 }
 
 // I have no idea why these operations wouldn't be infallible, tbh:
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PwmSetPeriodError(pub PwmPin); // TODO: review
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PwmSetDutyError(pub PwmPin); // TODO: review
 
 peripheral_trait! {pwm,

--- a/traits/src/peripherals/timers.rs
+++ b/traits/src/peripherals/timers.rs
@@ -11,8 +11,7 @@ use serde::{Deserialize, Serialize};
 // TODO: Add Errors
 // Timer periods: [0, core::u16::MAX)
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum TimerId {
     T0,
     T1,
@@ -37,8 +36,7 @@ pub const TIMERS: TimerArr<TimerId> = {
     TimerArr([T0, T1])
 };
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TimerArr<T>(pub [T; TimerId::NUM_TIMERS]);
 
 // Once const fn is more stable:
@@ -70,15 +68,14 @@ impl<T> IndexMut<TimerId> for TimerArr<T> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TimerState {
     Repeated,
     SingleShot,
     Disabled,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TimerMiscError;
 
 pub type TimerStateMismatch = (TimerId, TimerState);

--- a/traits/src/peripherals/timers.rs
+++ b/traits/src/peripherals/timers.rs
@@ -1,21 +1,22 @@
 //! [`Timers` trait](Timers) and related types.
 
 use crate::peripheral_trait;
-use core::ops::{Deref, Index, IndexMut};
 
-use core::sync::atomic::AtomicBool;
 use lc3_isa::Word;
+use lc3_macros::DisplayUsingDebug;
+
+use core::ops::{Deref, Index, IndexMut};
+use core::sync::atomic::AtomicBool;
 
 use serde::{Deserialize, Serialize};
 
 // TODO: Add Errors
 // Timer periods: [0, core::u16::MAX)
 
+#[rustfmt::skip]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub enum TimerId {
-    T0,
-    T1,
-}
+#[derive(DisplayUsingDebug)]
+pub enum TimerId { T0, T1, }
 
 impl TimerId {
     pub const NUM_TIMERS: usize = 2;

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1717,6 +1717,8 @@ fn get_pin_string(s: TuiState, g: GpioPin, a: AdcPin, p: PwmPin, t: TimerId, r: 
             A1 => return format!("A1"),
             A2 => return format!("A2"),
             A3 => return format!("A3"),
+            A4 => return format!("A4"),
+            A5 => return format!("A5"),
         },
         PWM => match p {
             P0 => return format!("P0"),

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1695,51 +1695,16 @@ fn input_mode_string(s: TuiState) -> String {
 }
 
 fn get_pin_string(s: TuiState, g: GpioPin, a: AdcPin, p: PwmPin, t: TimerId, r: Reg) -> String {
-    use AdcPin::*;
-    use GpioPin::*;
-    use PwmPin::*;
-    use Reg::*;
     use TuiState::*;
 
     match s {
-        GPIO => match g {
-            G0 => return format!("G0"),
-            G1 => return format!("G1"),
-            G2 => return format!("G2"),
-            G3 => return format!("G3"),
-            G4 => return format!("G4"),
-            G5 => return format!("G5"),
-            G6 => return format!("G6"),
-            G7 => return format!("G7"),
-        },
-        ADC => match a {
-            A0 => return format!("A0"),
-            A1 => return format!("A1"),
-            A2 => return format!("A2"),
-            A3 => return format!("A3"),
-            A4 => return format!("A4"),
-            A5 => return format!("A5"),
-        },
-        PWM => match p {
-            P0 => return format!("P0"),
-            P1 => return format!("P1"),
-        },
-        TMR => match t {
-            T0 => return format!("T0"),
-            T1 => return format!("T1"),
-        },
-        REG => match r {
-            R0 => return format!("R0"),
-            R1 => return format!("R1"),
-            R2 => return format!("R2"),
-            R3 => return format!("R3"),
-            R4 => return format!("R4"),
-            R5 => return format!("R5"),
-            R6 => return format!("R6"),
-            R7 => return format!("R7"),
-        },
-        CLK => return format!("CLK"),
-        PC => return format!("PC"),
+        GPIO => g.to_string(),
+        ADC => a.to_string(),
+        PWM => p.to_string(),
+        TMR => t.to_string(),
+        REG => r.to_string(),
+        CLK => format!("CLK"),
+        PC => format!("PC"),
         _ => return format!(""),
     }
 }


### PR DESCRIPTION
Includes:
  - switching from 4 to 6 ADC pins (b7942bd443bebffcfa35b44d00caaf977a9bb157)
  - being more consistent about derives (0e2f962af0aafe62f3087d118e80ff8084f2b8f4)
  - adding a derive macro that impls `Display` by just using `Debug` (0591cfdf49921e85af98fde1c56583815737d752)
    * and using it (1e8f00fc91c5986a6362ca440b9bfe4b9bbf6e01, 8db0923f3512d4e6f4359df190654062b01fe866)
