### PR TITLE
bench: add an i/o benchmark and add lc3tools to the benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ lc3-shims = { path = "shims", version = "0.1.0" }
 lc3-traits = { path = "traits", version = "0.1.0", default-features = false, features = [] } # Enable std features
 lc3-os = { path = "os", version = "0.1.0" }
 
+lc3tools-sys = { version = "1.0.6", git = "https://github.com/rrbutani/lc3tools-sys.git", branch = "main" }
+
 criterion = "0.3.0"
 async-std = "1.4.0"
 lazy_static = "1.4.0"
@@ -44,6 +46,7 @@ harness = false
 [features]
 default = []
 nightly = [] # For benchmarking.
+lto = ["lc3tools-sys/lto"] # For benchmarking.
 
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ harness = false
 name = "overhead"
 harness = false
 
+[[bench]]
+name = "io"
+harness = false
+
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,12 @@ lc3-shims = { path = "shims", version = "0.1.0" }
 lc3-traits = { path = "traits", version = "0.1.0", default-features = false, features = [] } # Enable std features
 lc3-os = { path = "os", version = "0.1.0" }
 
-lc3tools-sys = { version = "1.0.6", git = "https://github.com/rrbutani/lc3tools-sys.git", branch = "main" }
+lc3tools-sys = "=1.0.6-alpha2" # We can use the next point release (TODO).
 
 criterion = "0.3.0"
 async-std = "1.4.0"
 lazy_static = "1.4.0"
+pretty_assertions = "0.6.1"
 
 
 [[bench]]

--- a/baseline-sim/src/interp.rs
+++ b/baseline-sim/src/interp.rs
@@ -696,6 +696,7 @@ impl<'a, M: Memory, P: Peripherals<'a>> Interpreter<'a, M, P> {
 
     fn push(&mut self, word: Word) -> WriteAttempt {
         // This function will *only ever push onto the system stack*:
+        // TODO: report an error if it's in the I/O region somehow? it's not possible in regular use but it happened to me anyways (when getting the OS not to switch to user mode)
         if self[R6] <= lc3_isa::OS_START_ADDR {
             self.set_error(SystemStackOverflow);
             self.halt();

--- a/baseline-sim/src/mem_mapped.rs
+++ b/baseline-sim/src/mem_mapped.rs
@@ -191,8 +191,8 @@ pub trait Interrupt: MemMapped {
         <I as Deref>::Target: Peripherals<'a>,
     {
         // TODO: this is not true anymore, verify
-        // Important that interrupt_ready is first: we don't want to short circuit here!
-        Self::interrupt_ready(interp) && Self::interrupt_enabled(interp)
+        // Important that interrupt_enabled is first: we do want to short circuit here!
+        Self::interrupt_enabled(interp) && Self::interrupt_ready(interp)
     }
 
     // TODO: eventually, const

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -7,6 +7,7 @@ pub extern crate lc3_traits;
 pub extern crate lc3_os;
 
 pub extern crate lc3tools_sys;
+pub extern crate pretty_assertions;
 
 extern crate lazy_static;
 
@@ -14,6 +15,8 @@ pub use lc3_isa::{program, util::AssembledProgram};
 pub use lc3_isa::Word;
 
 pub use lc3_os::OS_IMAGE;
+
+pub use pretty_assertions::assert_eq as eq;
 
 pub const fn fib_program_executed_insn_count(num_iters: Word) -> u64 {
     (159 * (num_iters as u64) + 347)
@@ -213,7 +216,10 @@ where
 
 use lc3tools_sys::root::{
     lc3::sim as Lc3ToolsSimInner,
-    buffer_printer, buffer_inputter, callback_printer, callback_inputter, free_sim, get_mem, load_program, new_sim, new_sim_with_no_op_io, run_program, State as Lc3ToolsSimState,
+    buffer_printer, buffer_inputter, callback_printer, callback_inputter, free_sim,
+    get_mem, load_program, new_sim, new_sim_with_no_op_io, run_program,
+    State as Lc3ToolsSimState,
+    lc3::utils::PrintType_P_SIM_OUTPUT as PrintTypeSimOutput,
 };
 
 pub struct Lc3ToolsSim<'inp, 'out> {
@@ -225,7 +231,7 @@ pub struct Lc3ToolsSim<'inp, 'out> {
 impl<'inp, 'out> Lc3ToolsSim<'inp, 'out> {
     pub fn new() -> Self {
         Self {
-            sim: unsafe { new_sim_with_no_op_io() },
+            sim: unsafe { new_sim_with_no_op_io(PrintTypeSimOutput) },
             inp: None,
             out: None,
         }
@@ -242,6 +248,7 @@ impl<'inp, 'out> Lc3ToolsSim<'inp, 'out> {
                 new_sim(
                     buffer_printer(o_len as u64, o),
                     buffer_inputter(i_len as u64, i),
+                    PrintTypeSimOutput,
                 )
             },
             inp: Some(inp),
@@ -255,6 +262,7 @@ impl<'inp, 'out> Lc3ToolsSim<'inp, 'out> {
                 new_sim(
                     callback_printer(Some(output)),
                     callback_inputter(Some(input)),
+                    PrintTypeSimOutput,
                 )
             },
             inp: None,

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -10,10 +10,10 @@ pub extern crate lc3tools_sys;
 
 extern crate lazy_static;
 
-use lc3_isa::{program, util::AssembledProgram};
+pub use lc3_isa::{program, util::AssembledProgram};
 pub use lc3_isa::Word;
 
-use lc3_os::OS_IMAGE;
+pub use lc3_os::OS_IMAGE;
 
 pub const fn fib_program_executed_insn_count(num_iters: Word) -> u64 {
     (159 * (num_iters as u64) + 347)

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -365,6 +365,9 @@ fn bench_io(c: &mut Criterion) {
             &input_stream,
             &image_raw,
         );
+
+        // TODO: do one that uses interrupt I/O.
+        // (imp, low-pri)
     }
 }
 

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,0 +1,410 @@
+
+extern crate lc3_baseline_sim;
+extern crate lc3_isa;
+extern crate lc3_shims;
+extern crate lc3_traits;
+extern crate lc3_os;
+
+extern crate criterion;
+extern crate async_std;
+extern crate lazy_static;
+
+#[path = "common.rs"]
+mod common;
+use common::*;
+
+use lc3_traits::peripherals::input::{Input, InputError};
+use lc3_shims::peripherals::input::{InputShim, Source};
+
+use std::iter::{DoubleEndedIterator, Rev};
+use std::sync::{Arc, Mutex};
+
+pub struct BufferedInput<Iter: DoubleEndedIterator + Iterator<Item = u8>> {
+    buffer: Mutex<Rev<Iter>>,
+}
+
+impl<I: DoubleEndedIterator + Iterator<Item = u8>> BufferedInput<I> {
+    pub fn new(iter: I) -> Self {
+        Self {
+            buffer: Mutex::new(iter.rev()),
+        }
+    }
+}
+
+impl<I: DoubleEndedIterator + Iterator<Item = u8>> Source for BufferedInput<I> {
+    fn get_char(&self) -> Option<u8> {
+        // Some(dbg!(self.buffer.lock().unwrap().next().unwrap()))
+        // None
+        // panic!("what!!!!")
+        Some(dbg!(self.buffer.lock().unwrap().next().unwrap()))
+    }
+}
+
+use lc3_baseline_sim::interp::{Interpreter, InterpreterBuilder};
+use lc3_traits::peripherals::{stubs::{GpioStub, AdcStub, PwmStub, TimersStub, ClockStub, InputStub}, PeripheralSet};
+use lc3_shims::peripherals::output::{OutputShim, Sink};
+use lc3_shims::memory::MemoryShim;
+use lc3_isa::util::MemoryDump;
+
+pub fn interpreter<'b, 's>(
+    program: &MemoryDump,
+    flags: &'b PeripheralInterruptFlags,
+    inp: impl DoubleEndedIterator + Iterator<Item = u8> + Send + 's,
+    out: impl Sink + Send + Sync + 's,
+) -> Interpreter<
+    'b,
+    MemoryShim,
+    PeripheralSet<
+        'b,
+        GpioStub,
+        AdcStub,
+        PwmStub,
+        TimersStub,
+        ClockStub,
+        InputShim<'s, 'b>,
+        // InputStub,
+        OutputShim<'s, 'b>,
+    >
+> {
+    let memory = MemoryShim::new(**program);
+
+    let peripherals = PeripheralSet::new(
+        GpioStub,
+        AdcStub,
+        PwmStub,
+        TimersStub,
+        ClockStub,
+        InputShim::using(Box::new(BufferedInput::new(inp))),
+        // InputStub,
+        OutputShim::using(Box::new(out)),
+    );
+
+    let mut interp: Interpreter::<'b, MemoryShim, _> = InterpreterBuilder::new()
+        .with_defaults()
+        .with_peripherals(peripherals)
+        .with_memory(memory)
+        .build();
+
+    interp.reset();
+    interp.init(flags);
+
+    interp
+}
+
+fn byte_stream(elements: usize) -> impl Clone + DoubleEndedIterator + Iterator<Item = u8> {
+    (0..elements).map(|i| (((i % 256) + (i * i * i) - (i + 12)) % 256) as u8)
+}
+
+fn checksum(iter: impl Iterator<Item = u8>) -> u128 {
+    iter.fold(1u128, |acc, b| acc * ((b + 1) as u128))
+}
+
+// pub fn program(num_elements: u64) -> AssembledProgram {
+//     let prog = program! {
+//         // Disable PUTS to suppress the HALT message.
+//         .ORIG #(lc3_os::traps::builtin::PUTS as Word);
+//         .FILL @NEW_PUTS;
+
+//         .ORIG #0x4000;
+//         @NEW_PUTS RTI;
+
+//         .ORIG #0x3000;
+//         AND R0, R0, #0;
+//         ADD R0, R0, #12;
+
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+//         OUT;
+
+//         HALT;
+//     }.into();
+
+//     prog
+// }
+
+pub fn program(num_elements: u64) -> AssembledProgram {
+    let prog = program! {
+        // Disable PUTS to suppress the HALT message.
+        .ORIG #(lc3_os::traps::builtin::PUTS as Word);
+        .FILL @NEW_PUTS;
+
+        .ORIG #0x4000;
+        @NEW_PUTS RTI;
+
+
+        .ORIG #0x3000;
+        BRnzp @START;
+
+        // This is kinda cryptic but what's going on here is that we branch to
+        // the innermost loop, skipping the zero check for the 3 outer loops
+        // (we do this because if we didn't we'd exit prematurely when outer
+        // loop counters are zero even when inner loop counters are still
+        // non-zero).
+        //
+        // Because of this, we end up doing a subtract on the outer loop
+        // counters immediately once we get out of the innermost loop, which
+        // actually throws the count off since those loops haven't actually
+        // run yet. To compensate for this we add 1 to their counts. Note that
+        // is valid for Word::MAX_VALUE too (the value will start as 0 which
+        // wraps to MAX_VALUE when 1 is subtracted).
+        //
+        // We don't do this addition to the innermost loop because it's zero
+        // check actually does get run (that's our starting point).
+        //
+        // This is all pretty precarious but it lets us avoid lots of special
+        // cases and manual checks!
+        @C_A .FILL #(((num_elements >> 48) as Word).wrapping_add(1));
+        @C_B .FILL #(((num_elements >> 32) as Word).wrapping_add(1));
+        @C_C .FILL #(((num_elements >> 16) as Word).wrapping_add(1));
+        @C_D .FILL #(((num_elements >> 00) as Word).wrapping_add(0));
+
+        @START
+        LD R1, @C_A;
+        LD R2, @C_B;
+        LD R3, @C_C;
+        LD R4, @C_D;
+
+        BRnzp @D_LOOP;
+
+        @A_LOOP
+            BRz @A_END;
+
+            @B_LOOP
+                BRz @B_END;
+
+                @C_LOOP
+                    BRz @C_END;
+
+                    @D_LOOP
+                        BRz @D_END;
+
+                        GETC;
+                        OUT;
+
+                        ADD R4, R4, #-1;
+                        BRnzp @D_LOOP;
+
+                    @D_END
+                        ADD R4, R4, #-1;
+                        ADD R3, R3, #-1;
+                        BRnzp @C_LOOP;
+
+                @C_END
+                    ADD R3, R3, #-1;
+                    ADD R2, R2, #-1;
+                    BRnzp @B_LOOP;
+
+            @B_END
+                ADD R2, R2, #-1;
+                ADD R1, R1, #-1;
+                BRnzp @A_LOOP;
+
+        @A_END
+            HALT;
+    }.into();
+
+    prog
+}
+
+const SIZES: [u64; 5] = [10, 10, 100, 1000, 10_000];
+
+use criterion::{BatchSize, BenchmarkId, Bencher, Criterion, Throughput, PlotConfiguration, AxisScale};
+use criterion::measurement::WallTime;
+use lc3_baseline_sim::interp::MachineState;
+
+use std::time::{Duration, Instant};
+
+fn bench_io(c: &mut Criterion) {
+    let flags = PeripheralInterruptFlags::new();
+    let mut group = c.benchmark_group("i/o throughput");
+
+    let plot_config = PlotConfiguration::default()
+        .summary_scale(AxisScale::Logarithmic);
+
+    group.plot_config(plot_config);
+
+    for size in SIZES.iter() {
+        group.throughput(Throughput::Bytes(*size));
+
+        let input_stream: Vec<u8> = byte_stream(*size as usize + 12).collect();
+
+        let program = program(*size);
+        let image = {
+            let mut image = OS_IMAGE.clone();
+            image.layer_loadable(&program);
+
+            image
+        };
+
+        lc3_shims::memory::FileBackedMemoryShim::with_initialized_memory("dump.mem", image.clone()).flush_all_changes().unwrap();
+
+        // fn lc3tools_inner<'a>(
+        //     b: &mut Bencher<'a, WallTime>,
+        //     prog: &AssembledProgram,
+        //     inp: &'a Vec<u8>,
+        //     out: &'a mut Vec<u8>,
+        // ) {
+        //     b.iter_batched(
+        //         || {
+        //             let mut sim = Lc3ToolsSim::<'a, 'a>::new_with_buffers(inp, out);
+        //             sim.load_program(prog);
+        //             sim
+        //         },
+        //         |sim| sim.run(0x3000).unwrap(),
+        //         BatchSize::SmallInput,
+        //     )
+        // }
+
+        // fn lc3tools<'a>(
+        //     group: &mut BenchmarkGroup<'a, WallTime>,
+        //     size: u64,
+        //     prog: &AssembledProgram,
+        //     inp: &'a Vec<u8>,
+        //     out: &'a mut Vec<u8>,
+        // ) {
+        //     group.bench_with_input(
+        //         BenchmarkId::new("LC3Tools", size),
+        //         &size,
+        //         |b, _size| lc3tools_inner(b, prog, inp, out)
+        //     );
+
+        //     assert_eq!(inp, out);
+        // }
+
+        // lc3tools(
+        //     &mut group,
+        //     *size,
+        //     &program,
+        //     &input_stream,
+        //     &mut output_stream,
+        // );
+
+        // fn lc3tools_inner<'a, 's: 'a>(
+        //     b: &'a mut Bencher<'a, WallTime>,
+        //     prog: &AssembledProgram,
+        //     inp: &'s Vec<u8>,
+        //     out: &'s mut Vec<u8>,
+        // ) {
+        //     b.iter_batched_ref(
+        //         || {
+        //             let mut sim = Lc3ToolsSim::<'a, 'a>::new_with_buffers(inp, out);
+        //             sim.load_program(prog);
+        //             sim
+        //         },
+        //         |sim| sim.run(0x3000).unwrap(),
+        //         BatchSize::SmallInput,
+        //     )
+        // }
+
+/*        group.bench_with_input(
+            BenchmarkId::new("LC3Tools", *size),
+            size,
+            |b, size| {
+                let mut out = Vec::with_capacity(*size as usize);
+
+                // b.iter_batched(|| {
+                //         let mut sim = Lc3ToolsSim::new_with_buffers(&input_stream, &mut out);
+                //         sim.load_program(&program);
+                //         sim
+                //     },
+                //     |sim| sim.run(0x3000).unwrap(),
+                //     BatchSize::SmallInput,
+                // );
+
+                // lc3tools_inner(b, &program, &input_stream, &mut out);
+
+                b.iter_custom(|iters| {
+                    let mut acc = Duration::new(0, 0);
+                    for _ in 0..iters {
+                        let mut sim = Lc3ToolsSim::new_with_buffers(&input_stream, &mut out);
+                        sim.load_program(&program);
+
+                        let start = Instant::now();
+                        criterion::black_box(sim.run(0x3000).unwrap());
+                        acc += start.elapsed();
+
+                        drop(sim);
+                        // assert_eq!(input_stream, out);
+                    }
+
+                    acc
+                })
+            }
+        );*/
+
+
+        // group.bench_with_input(
+        //     BenchmarkId::new("Bare Interpreter", *size),
+        //     size,
+        //     |b, size| {
+        //         let mut output = Arc::new(Mutex::new(Vec::with_capacity(*size as usize)));
+        //         let mut int = interpreter(&image, &flags, input_stream.iter().copied(), output.clone());
+
+        //         b.iter(|| {
+        //             int.reset();
+        //             while let MachineState::Running = int.step() {}
+        //         });
+
+        //         let mut out = output.lock().unwrap();
+        //         assert_eq!(input_stream, *out);
+
+        //         out.drain(..);
+        //     }
+        // );
+
+        group.bench_with_input(
+            BenchmarkId::new("Bare Interpreter", *size),
+            size,
+            |b, size| {
+                b.iter_custom(|iters| {
+                    let mut acc = Duration::new(0, 0);
+
+                    for _ in 0..iters {
+                        let mut output = Vec::<u8>::with_capacity(*size as usize);
+                        let borrow = Mutex::new(&mut output);
+                        let mut int = interpreter(&image, &flags, input_stream.iter().copied(), borrow);
+
+                        // let mut int = bare_interpreter(image.clone(), &flags);
+
+                        println!("START!");
+                        let start = Instant::now();
+                        while let MachineState::Running = int.step() {}
+                        acc += start.elapsed();
+                        println!("END!");
+
+                        drop(int);
+                        assert_eq!(input_stream, output);
+                    }
+
+                    acc
+                });
+            }
+        );
+
+        // group.bench_with_input(
+        //     BenchmarkId::new("Bare Interpreter - step", *num_iter),
+        //     num_iter,
+        //     |b, num| {
+        //         // eprintln!("hello!");
+        //         // println!("hello!");
+        //         let mut int = black_box(bare_interpreter(build_fib_memory_image(*num), &flags));
+        //         b.iter(|| {
+        //             int.reset();
+        //             while let MachineState::Running = int.step() {}
+        //         })
+        //     },
+        // );
+    }
+}
+
+use criterion::{criterion_group, criterion_main};
+
+criterion_group!(benches, bench_io);
+criterion_main!(benches);

--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -50,6 +50,18 @@ fn bench_fib(c: &mut Criterion) {
         )));
 
         group.bench_with_input(
+            BenchmarkId::new("LC3Tools", *num_iter),
+            num_iter,
+            |b, num| {
+                let mut sim = Lc3ToolsSim::new();
+                sim.load_program(&fib_program(*num));
+                b.iter(|| {
+                    sim.run(0x3000).unwrap();
+                })
+            }
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("Bare Interpreter - step", *num_iter),
             num_iter,
             |b, num| {

--- a/benches/speed.rs
+++ b/benches/speed.rs
@@ -40,6 +40,18 @@ fn bench_fib(c: &mut Criterion) {
         )));
 
         group.bench_with_input(
+            BenchmarkId::new("LC3Tools", *num_iter),
+            num_iter,
+            |b, num| {
+                let mut sim = Lc3ToolsSim::new();
+                sim.load_program(&fib_program(*num));
+                b.iter(|| {
+                    sim.run(0x3000).unwrap();
+                })
+            }
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("Bare Interpreter - step", *num_iter),
             num_iter,
             |b, num| {
@@ -68,12 +80,12 @@ fn bench_fib_alt() {
 
 use criterion::{criterion_group, criterion_main};
 
-// criterion_group!(benches, bench_fib);
-// criterion_main!(benches);
+criterion_group!(benches, bench_fib);
+criterion_main!(benches);
 
-fn main() {
-    let mut crit = Default::default();
+// fn main() {
+//     let mut crit = Default::default();
 
-    bench_fib(&mut crit);
-    // bench_fib_alt();
-}
+//     bench_fib(&mut crit);
+//     // bench_fib_alt();
+// }

--- a/os/src/os.rs
+++ b/os/src/os.rs
@@ -1785,3 +1785,5 @@ fn os() -> AssembledProgram {
 
     AssembledProgram::new(os)
 }]}
+
+// TODO: offer a variant of this that has the OS be silent (no HALT, ACV, etc. messages).

--- a/os/src/os.rs
+++ b/os/src/os.rs
@@ -1818,3 +1818,12 @@ fn os() -> AssembledProgram {
 }]}
 
 // TODO: offer a variant of this that has the OS be silent (no HALT, ACV, etc. messages).
+
+// TODO: verify that the <0x3000, no user mode thing works as we expect it to..
+//  - we should have tests for this (i.e. branches to the right spot, no ACVs this way, ACVs the other way)
+//  - i don't think there's any problem with RTI-ing back to system mode but someone should check me on this
+//  - open q: is it okay that we don't do anything if the starting address is in the
+//    mem mapped region? you just immediately crash with an ACV, is what happens.
+//   - we should probably add documentation explaining that you've got to be careful about the stack pointer when you do this (i.e. don't clobber R6 or you can't use the traps or take interrupts)
+//       + as an example, I set R6 to a mem mapped address which actually — inexplicably — caused the machine to hang..
+//           * when it went to HALT, it tried to push onto the memory mapped location as part of servicing the TRAP which is definitely weird but shouldn't cause a hang... (TODO?)

--- a/os/tests/smoke.rs
+++ b/os/tests/smoke.rs
@@ -8,5 +8,5 @@ use lti::{assert_eq, with_larger_stack};
 
 #[test]
 fn os_size() {
-    with_larger_stack(None, || assert_eq!(OS.into_iter().count(), 0x052C));
+    with_larger_stack(None, || assert_eq!(OS.into_iter().count(), 0x0535 /*1333*/));
 }

--- a/shims/src/peripherals/input.rs
+++ b/shims/src/peripherals/input.rs
@@ -124,6 +124,10 @@ impl<'int, 'i> InputShim<'i, 'int> {
         InputShim::sourced_from(OwnedOrRef::Ref(source))
     }
 
+    // TODO: this seems wrong; why are we dropping unread data here?
+    //
+    // Note that since this gets called when we check for interrupts we'll just
+    // drop data repeatedly when this interrupt is enabled.
     fn fetch_latest(&self) {
         let new_data = self.source.get_char();
         if let Some(c) = new_data {

--- a/shims/src/peripherals/input.rs
+++ b/shims/src/peripherals/input.rs
@@ -124,11 +124,6 @@ impl<'int, 'i> InputShim<'i, 'int> {
         InputShim::sourced_from(OwnedOrRef::Ref(source))
     }
 
-    // TODO: this seems wrong; why are we dropping unread data here?
-    //
-    // Note that since this gets called when we check for interrupts we'll just
-    // drop data repeatedly when this interrupt is enabled.
-    //
     // TODO: we're duplicating state here: both the flag and `data` indicate
     // whether we've got a char that hasn't been read yet.
     fn fetch_latest(&self) {

--- a/shims/src/peripherals/input.rs
+++ b/shims/src/peripherals/input.rs
@@ -25,7 +25,7 @@ pub trait Source {
 
 impl<S: Source> Source for Arc<S> {
     fn get_char(&self) -> Option<u8> {
-        self.get_char()
+        <S as Source>::get_char(self)
     }
 }
 
@@ -128,13 +128,17 @@ impl<'int, 'i> InputShim<'i, 'int> {
     //
     // Note that since this gets called when we check for interrupts we'll just
     // drop data repeatedly when this interrupt is enabled.
+    //
+    // TODO: we're duplicating state here: both the flag and `data` indicate
+    // whether we've got a char that hasn't been read yet.
     fn fetch_latest(&self) {
-        let new_data = self.source.get_char();
-        if let Some(c) = new_data {
-            self.data.replace(Some(c));
-            match self.flag {
-                Some(flag) => flag.store(true, Ordering::SeqCst),
-                None => unreachable!(),
+        if let None = self.data.get() {
+            if let Some(c) = self.source.get_char() {
+                self.data.set(Some(c));
+                match self.flag {
+                    Some(flag) => flag.store(true, Ordering::SeqCst),
+                    None => unreachable!(),
+                }
             }
         }
     }

--- a/shims/src/peripherals/input.rs
+++ b/shims/src/peripherals/input.rs
@@ -184,7 +184,7 @@ impl<'inp, 'int> Input<'int> for InputShim<'inp, 'int> {
             Some(flag) => flag.store(false, Ordering::SeqCst),
             None => unreachable!(),
         }
-        self.data.get().ok_or(InputError::NoDataAvailable)
+        self.data.take().ok_or(InputError::NoDataAvailable)
     }
 
     fn current_data_unread(&self) -> bool {

--- a/shims/src/peripherals/mod.rs
+++ b/shims/src/peripherals/mod.rs
@@ -1,15 +1,15 @@
 //! Shims for the various [peripheral traits](crate::peripherals).
 
 // Peripherals:
-mod adc;
-mod clock;
-mod gpio;
-mod pwm;
-mod timers;
+pub mod adc;
+pub mod clock;
+pub mod gpio;
+pub mod pwm;
+pub mod timers;
 
 // Devices:
-mod input;
-mod output;
+pub mod input;
+pub mod output;
 
 use lc3_traits::peripherals::PeripheralSet;
 

--- a/shims/src/peripherals/output.rs
+++ b/shims/src/peripherals/output.rs
@@ -109,9 +109,9 @@ impl<'out, 'int> Output<'int> for OutputShim<'out, 'int> {
 
     // TODO: handle OutputErrors to somehow report that the write or flush went wrong
     fn write_data(&mut self, c: u8) -> Result<(), OutputError> {
-        if !c.is_ascii() {
-            return Err(OutputError::NonUnicodeCharacter(c));
-        }
+        // if !c.is_ascii() {
+        //     return Err(OutputError::NonUnicodeCharacter(c));
+        // }
 
         match self.flag {
             Some(f) => f.store(false, Ordering::SeqCst),

--- a/shims/src/peripherals/output.rs
+++ b/shims/src/peripherals/output.rs
@@ -112,6 +112,7 @@ impl<'out, 'int> Output<'int> for OutputShim<'out, 'int> {
         // if !c.is_ascii() {
         //     return Err(OutputError::NonUnicodeCharacter(c));
         // }
+        // ^ TODO!
 
         match self.flag {
             Some(f) => f.store(false, Ordering::SeqCst),


### PR DESCRIPTION
This ended up doing a few other things including:
  - adding the "don't switch to user mode if the starting address is <`0x3000`" thing that we've been meaning to add to the OS
  - fixing a couple of bugs in the `InputShim`

Both of these things could use some more attention down the road (some tests for the former and some clean up for the latter).

Everything else in this PR actually is just for the benchmarks.

Closes #114.