### PR TITLE
reorder timer trap insts

### DIFF
--- a/os/src/os.rs
+++ b/os/src/os.rs
@@ -1501,16 +1501,16 @@ fn os() -> AssembledProgram {
             STR R7, R6, #1;
             STR R1, R6, #0;
 
+            LD R1, @OS_TIMER_BASE_INTVEC;
+            ADD R1, R1, R0;
+            STR R2, R1, #0;
+
             AND R1, R1, #0;
             JSR @SET_TIMER_MODE;
 
             LDR R1, R6, #0;                 // Restore R1
             ADD R6, R6, #1;
             JSR @WRITE_TIMER_PERIOD;
-
-            LD R1, @OS_TIMER_BASE_INTVEC;
-            ADD R1, R1, R0;
-            STR R2, R1, #0;
 
             LDR R7, R6, #0;                 // Restore R7
             ADD R6, R6, #1;
@@ -1525,6 +1525,10 @@ fn os() -> AssembledProgram {
             STR R7, R6, #1;
             STR R1, R6, #0;
 
+            LD R1, @OS_TIMER_BASE_INTVEC;
+            ADD R1, R1, R0;
+            STR R2, R1, #0;
+
             AND R1, R1, #0;
             ADD R1, R1, #1;
             JSR @SET_TIMER_MODE;
@@ -1532,10 +1536,6 @@ fn os() -> AssembledProgram {
             LDR R1, R6, #0;                 // Restore R1
             ADD R6, R6, #1;
             JSR @WRITE_TIMER_PERIOD;
-
-            LD R1, @OS_TIMER_BASE_INTVEC;
-            ADD R1, R1, R0;
-            STR R2, R1, #0;
 
             LDR R7, R6, #0;                 // Restore R7
             ADD R6, R6, #1;


### PR DESCRIPTION
The purpose of this PR is to reorder the timer trap LC-3 instruction sequence.
Problem - When the timer is initialized with interrupts, and the mode is set to enabled with period, and it turns out the period
is really small or the hardware device had already been generated but was masked by Disabled state, then since interrupts are
checked every instruction, it's possible to trigger the interrupt before even the ISR address entry is initialized. This leads to
going to default handler and halts.
Fix - This PR simply reorders the trap instructions for timer to first load the ISR vector entry, then set mode and period