### PR TITLE
Clean up the Cargo features across the project

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,3 +10,7 @@ docs = [
     "-Z", "unstable-options", '--config=build.rustdocflags=["--cfg", "docs"]',
     "doc", "--all", "--document-private-items", "--all-features"
 ]
+# Stable equivalent of the above.
+docs-stable = [
+    "doc", "--all", "--document-private-items"
+]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,12 @@
+[build]
+
+# Ordinarily we would just set this but: we don't want to break regular
+# `cargo doc` for developers that don't have a nightly toolchain installed.
+# rustdocflags = ["--cfg", "docs"]
+
+[alias]
+# Requires `nightly` Rust!
+docs = [
+    "-Z", "unstable-options", '--config=build.rustdocflags=["--cfg", "docs"]',
+    "doc", "--all", "--document-private-items", "--all-features"
+]

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Nix stuff
+.direnv

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ At the moment, the primary 'users' of the platform are the following:
      + Lives in the [`lc3-device-support` crate](device-support).
      + TODO: move out of this repo!
 
+## For Developers
+
+TODO: fill in
+
+To build the docs for the project:
+  - `cargo +nightly docs` (`cargo-nightly docs` if using `nix`)
+    + NOTE: this requires a nightly Rust toolchain!
+    + If you're on stable you can instead run: `cargo docs-stable` to get mostly identical output
+
+
 TODO:
  - [ ] crate and doc badges on each crate
  - [ ] doc badge to gh pages on the top level README (this file)

--- a/application-support/Cargo.toml
+++ b/application-support/Cargo.toml
@@ -44,6 +44,11 @@ js-sys = "0.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 
-
 [dev-dependencies]
 pretty_assertions = "0.6.1"
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/application-support/Cargo.toml
+++ b/application-support/Cargo.toml
@@ -29,7 +29,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 lc3-shims = { path = "../shims", version = "0.1.0" }
-lc3-traits = { path = "../traits", version = "0.1.0", default-features = false, features = ["json_encoding_layer"] } # Enable std features
+lc3-traits = { path = "../traits", version = "0.1.0", features = ["std", "json_encoding_layer"] } # Enable std features
 lc3-baseline-sim = { path = "../baseline-sim", version = "0.1.0", default-features = false }
 lc3-device-support = { path = "../device-support", version = "0.1.0", default-features = false, features = ["host_transport"] }
 

--- a/application-support/src/lib.rs
+++ b/application-support/src/lib.rs
@@ -42,14 +42,18 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! not_wasm {
     ($($i:item)*) => {
-        $( #[cfg(not(target_arch = "wasm32"))] $i )*
+        $(
+            #[cfg_attr(all(docs, not(doctest)), doc(not(target_arch = "wasm32")))]
+            #[cfg(not(target_arch = "wasm32"))]
+            $i
+        )*
     };
 }
 
@@ -57,7 +61,11 @@ macro_rules! not_wasm {
 #[macro_export]
 macro_rules! wasm {
     ($($i:item)*) => {
-        $( #[cfg(target_arch = "wasm32")] $i )*
+        $(
+            #[cfg_attr(all(docs, not(doctest)), doc(target_arch = "wasm32"))]
+            #[cfg(target_arch = "wasm32")]
+            $i
+        )*
     };
 }
 

--- a/baseline-sim/Cargo.toml
+++ b/baseline-sim/Cargo.toml
@@ -45,7 +45,7 @@ path = "tests/device_register_tests/mod.rs"
 
 [features]
 default = []
-no_std = ["lc3-traits/no_std", "lc3-isa/no_std"]
+std = ["lc3-traits/std", "lc3-isa/std"]
 
 [package.metadata.docs.rs]
 # targets = [""]

--- a/baseline-sim/Cargo.toml
+++ b/baseline-sim/Cargo.toml
@@ -46,3 +46,9 @@ path = "tests/device_register_tests/mod.rs"
 [features]
 default = []
 no_std = ["lc3-traits/no_std", "lc3-isa/no_std"]
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/baseline-sim/src/lib.rs
+++ b/baseline-sim/src/lib.rs
@@ -48,13 +48,12 @@
 #![doc(html_logo_url = "")] // TODO!
 // TODO: add doc URL to all
 
-// Mark the crate as no_std if the `no_std` feature is enabled.
-#![cfg_attr(feature = "no_std", no_std)]
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 extern crate static_assertions as sa;
 
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
+extern crate static_assertions as sa;
 
 pub mod interp;
 pub mod mem_mapped;

--- a/baseline-sim/src/lib.rs
+++ b/baseline-sim/src/lib.rs
@@ -51,7 +51,8 @@
 // Enable the `doc_cfg` feature when running rustdoc.
 #![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
-extern crate static_assertions as sa;
+// Mark the crate as no_std if the `std` feature is **not** enabled.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate static_assertions as sa;
 

--- a/device-support/Cargo.toml
+++ b/device-support/Cargo.toml
@@ -52,9 +52,9 @@ pretty_assertions = "0.6.1"
 
 [features]
 default = []
-no_std = ["lc3-isa/no_std", "lc3-traits/no_std"]
+std = ["lc3-isa/std", "lc3-traits/std"]
 alloc = ["bytes"]
-host_transport = ["serialport"]
+host_transport = ["std", "serialport"]
 
 [package.metadata.docs.rs]
 # targets = [""]

--- a/device-support/Cargo.toml
+++ b/device-support/Cargo.toml
@@ -55,3 +55,9 @@ default = []
 no_std = ["lc3-isa/no_std", "lc3-traits/no_std"]
 alloc = ["bytes"]
 host_transport = ["serialport"]
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/device-support/src/lib.rs
+++ b/device-support/src/lib.rs
@@ -49,10 +49,12 @@
 #![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 macro_rules! using_std { ($($i:item)*) => ($(
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "std")))]
     #[cfg(feature = "std")]
     $i
 )*) }
 macro_rules! using_alloc { ($($i:item)*) => ($(
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     $i
 )*) }

--- a/device-support/src/lib.rs
+++ b/device-support/src/lib.rs
@@ -42,16 +42,22 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
-// Mark the crate as no_std if the `no_std` feature is enabled.
-#![cfg_attr(feature = "no_std", no_std)]
+// Mark the crate as no_std if the `std` feature is *not* enabled.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 // Enable the `doc_cfg` feature when running rustdoc.
 #![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
-using_alloc! { #[allow(unused_extern_crates)] extern crate alloc; }
+macro_rules! using_std { ($($i:item)*) => ($(
+    #[cfg(feature = "std")]
+    $i
+)*) }
+macro_rules! using_alloc { ($($i:item)*) => ($(
+    #[cfg(feature = "alloc")]
+    $i
+)*) }
 
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
+using_alloc! { #[allow(unused_extern_crates)] extern crate alloc; }
 
 extern crate static_assertions as sa;
 

--- a/device-support/src/lib.rs
+++ b/device-support/src/lib.rs
@@ -45,8 +45,8 @@
 // Mark the crate as no_std if the `no_std` feature is enabled.
 #![cfg_attr(feature = "no_std", no_std)]
 
-macro_rules! using_std { ($($i:item)*) => ($(#[cfg(not(feature = "no_std"))]$i)*) }
-macro_rules! using_alloc { ($($i:item)*) => ($(#[cfg(feature = "alloc")]$i)*) }
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 using_alloc! { #[allow(unused_extern_crates)] extern crate alloc; }
 

--- a/device-support/src/memory/simple.rs
+++ b/device-support/src/memory/simple.rs
@@ -55,7 +55,6 @@ use lc3_traits::control::load::Index as IndexWrapper;
 /// 24 of these pages will occupy 12KiB of RAM, which we should be able to
 /// handle.
 ///
-#[repr(packed)]
 pub struct PartialMemory {
     program_data: ProgramMetadata,
     pages: [[Word; Self::PAGE_SIZE]; 24],
@@ -63,14 +62,19 @@ pub struct PartialMemory {
     void: Word,
 }
 
+// We keep this check in, in addition to the assertion below because this gives
+// us a better error message.
+//
+// The point of these checks is to guard against accidental changes to the size
+// of this type since we care a lot about how much space it ends up taking up.
 static __PARTIAL_MEM_SIZE_CHK: () = {
     let canary = [()];
     let size = core::mem::size_of::<PartialMemory>();
 
-    canary[size - ((24 * 512) + 8 + 28)]
+    canary[size - ((24 * 512) + 8 + 28 + /* padding */ 4)]
 };
 
-sa::const_assert!(core::mem::size_of::<PartialMemory>() == (24 * 512) + 8 + 28);
+sa::const_assert!(core::mem::size_of::<PartialMemory>() == (24 * 512) + 8 + 28 + /* padding */ 4);
 
 impl PartialMemory {
     const PAGE_SIZE: usize = 0x0100; // TODO: Use `PageAccess`?

--- a/device-support/src/rpc/transport/mod.rs
+++ b/device-support/src/rpc/transport/mod.rs
@@ -14,6 +14,7 @@ sa::const_assert!(fifo::CAPACITY >= (3 * size_of::<ResponseMessage>()));
 pub mod uart_simple;
 
 using_std! {
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(all(feature = "host_transport", not(target_arch = "wasm32")))))]
     #[cfg(all(feature = "host_transport", not(target_arch = "wasm32")))]
     pub mod uart_host;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,110 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656782578,
+        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1656401090,
+        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "locked": {
+        "lastModified": 1657372868,
+        "narHash": "sha256-yXzNQRlQMCYJJn4fA+zZNj3W0t9w+WDeCKG7D86YkTE=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "38f00cf4ee1dab9c10883b1d464486f0c040bb80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nur": "nur",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1657334765,
+        "narHash": "sha256-cK7EL1oIQT+34bbpKXXXDJalMUweuLIhL1T2b1H/oMQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "0d7f0e438ed7751be2e48f1fe1cb83869a3c81fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "UTP Core Flake";
+
+  # TODO: add the UTP cachix cache!
+
+  inputs = {
+    nixpkgs.url      = github:NixOS/nixpkgs/nixos-21.11;
+    rust-overlay.url = github:oxalica/rust-overlay;
+    flake-utils.url  = github:numtide/flake-utils;
+    nur.url          = github:nix-community/NUR;
+  };
+
+  # TODO: cargo extensions (cargo-expand)
+  # TODO: CI setup? (garnix)
+  # TODO: expose targets, etc.
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, nur }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # TODO: make a nixpkg of its own and upstream:
+        gdb-tools = pkgs: with pkgs.python3Packages; buildPythonPackage rec {
+          pname = "gdb-tools";
+          version = "1.4";
+
+          propagatedBuildInputs = [ arpeggio ];
+          src = fetchPypi {
+            inherit pname version;
+            sha256 = "NYtmI+0qeVx58vy49CRMEZw1jzZOgwElHUVIE1VpNEc=";
+          };
+
+          format = "pyproject";
+
+          meta = with pkgs.lib; {
+            # maintainers = with maintainers; [ TODO ];
+            # description = "TODO"
+            # license = bsd clause 3
+          };
+        };
+
+        overlays = [ (import rust-overlay) nur.overlay ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # `gdb` is broken on ARM macOS so we'll fallback to using x86_64 GDB
+        # there (assuming Rosetta is installed: https://github.com/NixOS/nix/pull/4310).
+        #
+        # See: https://github.com/NixOS/nixpkgs/issues/147953
+        gdbPkgs' = let
+          pkgs' = if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64 then
+            (import nixpkgs { system = "x86_64-darwin"; inherit overlays; })
+          else
+            pkgs;
+        in
+          [ pkgs'.gdb pkgs'.nur.repos.mic92.gdb-dashboard (gdb-tools pkgs') ]
+        ;
+
+        # As per https://github.com/ut-utp/.github/wiki/Dev-Environment-Setup#embedded-development-setup
+        # on Linux we need to expose `gdb` as `gdb-multiarch`
+        # (to match other distros):
+        gdbPkgs = if pkgs.stdenv.isLinux then
+          let
+            baseGdb = builtins.head gdbPkgs';
+            gdbMultiarch = pkgs.stdenvNoCC.mkDerivation {
+              pname = "gdb-multiarch";
+              inherit (baseGdb) version meta;
+              nativeBuildInputs = with pkgs; [ makeWrapper ];
+              unpackPhase = "true";
+              installPhase = ''
+                mkdir -p $out/bin
+                makeWrapper ${baseGdb}/bin/gdb $out/bin/gdb-multiarch
+              '';
+            };
+          in
+          [gdbMultiarch] ++ gdbPkgs'
+        else
+          gdbPkgs';
+
+        rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
+        llvm-tools-preview = builtins.head (builtins.filter (p: p.pname == "llvm-tools-preview") rust-toolchain.paths);
+
+        # Should bump this manually rather than always grab the newest, I think.
+        nightly-rust-toolchain = with pkgs.rust-bin; (nightly."2022-07-02".default);
+        # nightly-rust-toolchain = with pkgs.rust-bin; (selectLatestNightlyWith (toolchain: toolchain.default));
+
+        cargo-nightly = pkgs.writeShellScriptBin "cargo-nightly" ''
+          export RUSTC="${nightly-rust-toolchain}/bin/rustc";
+          export CARGO="${nightly-rust-toolchain}/bin/cargo";
+          export RUSTDOC="${nightly-rust-toolchain}/bin/rustdoc";
+          export RUSTFMT="${nightly-rust-toolchain}/bin/rustfmt";
+          # TODO: clippy
+          exec "$CARGO" "$@"
+        '';
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell {
+          buildInputs = [
+            rust-toolchain
+            cargo-nightly
+
+            cargo-bloat cargo-asm cargo-expand
+          ] ++ gdbPkgs;
+        };
+      }
+    );
+}

--- a/isa/Cargo.toml
+++ b/isa/Cargo.toml
@@ -46,3 +46,9 @@ strict = []
 
 # arbitrary = ["arbitrary"] is implict and can't be used with `no_std`
 nightly-const = [] # Requires nightly; isn't tested by CI.
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/isa/Cargo.toml
+++ b/isa/Cargo.toml
@@ -40,11 +40,11 @@ pretty_assertions = "0.6.1"
 
 
 [features]
-default = ["no_std"]
-no_std = []
+default = []
+std = []
 strict = []
 
-# arbitrary = ["arbitrary"] is implict and can't be used with `no_std`
+arbitrary = ["dep:arbitrary", "std"]
 nightly-const = [] # Requires nightly; isn't tested by CI.
 
 [package.metadata.docs.rs]

--- a/isa/src/lib.rs
+++ b/isa/src/lib.rs
@@ -42,8 +42,8 @@
 #![doc(test(attr(deny(warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
-// Mark the crate as no_std if the `no_std` feature is enabled.
-#![cfg_attr(feature = "no_std", no_std)]
+// Mark the crate as no_std if the `std` feature is **not** enabled.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 // Enable the `doc_cfg` feature when running rustdoc.
 #![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]

--- a/isa/src/lib.rs
+++ b/isa/src/lib.rs
@@ -52,16 +52,26 @@
 // this is fine for now.
 #![cfg_attr(feature = "nightly-const", feature(const_if_match))]
 #![cfg_attr(feature = "nightly-const", feature(const_panic))]
-#![cfg_attr(feature = "nightly-const", feature(const_fn))]
 
 // Makes some an item const if the nightly-const feature is activated and not
 // const otherwise.
+#[macro_export]
+#[doc(hidden)]
 macro_rules! nightly_const {
-    ([$($vis:tt)*] => [$($rest:tt)*]) => (
+    (
+        $( $(#[$m:meta])+ )?
+        [$($vis:tt)*] => [$($rest:tt)*]
+    ) => (
         #[cfg(not(feature = "nightly-const"))]
+        $( $(#[$m:meta])+ )?
+        ///
+        /// **NOTE**: This is only `const` when the `nightly-const` feature is enabled!
         $($vis)* $($rest)*
 
         #[cfg(feature = "nightly-const")]
+        $( $(#[$m:meta])+ )?
+        ///
+        /// **NOTE**: This is only `const` when the `nightly-const` feature is enabled!
         $($vis)* const $($rest)*
     );
 }

--- a/isa/src/lib.rs
+++ b/isa/src/lib.rs
@@ -45,6 +45,9 @@
 // Mark the crate as no_std if the `no_std` feature is enabled.
 #![cfg_attr(feature = "no_std", no_std)]
 
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
+
 // Note: this feature is not tested by CI (still dependent on nightly Rust) but
 // this is fine for now.
 #![cfg_attr(feature = "nightly-const", feature(const_if_match))]
@@ -62,9 +65,6 @@ macro_rules! nightly_const {
         $($vis)* const $($rest)*
     );
 }
-
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
 
 extern crate static_assertions as sa;
 

--- a/isa/tests/macros.rs
+++ b/isa/tests/macros.rs
@@ -7,7 +7,7 @@ use lc3_isa::util::AssembledProgram;
 
 use pretty_assertions::assert_eq;
 
-
+#[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "nightly-const")))]
 #[cfg(feature = "nightly-const")]
 const CONST_LOADABLE_TEST: [(lc3_isa::Addr, lc3_isa::Word); 28] = lc3_isa::loadable! {
     .ORIG #0x3000  => is the program start;
@@ -54,6 +54,7 @@ const CONST_LOADABLE_TEST: [(lc3_isa::Addr, lc3_isa::Word); 28] = lc3_isa::loada
     .FILL #0x23u16;
 };
 
+#[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "nightly-const")))]
 #[cfg(feature = "nightly-const")]
 const CONST_PROGRAM_TEST: [(lc3_isa::Word, bool); lc3_isa::ADDR_SPACE_SIZE_IN_WORDS] = lc3_isa::program! {
     .ORIG #0x3000  => is the program start;

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -39,3 +39,9 @@ syn = { version = "1.0.5" } # features = ["derive", "visit-mut", "parsing", "ful
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -42,6 +42,9 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
+
 extern crate proc_macro;
 use proc_macro2::Span;
 use quote::quote_spanned;

--- a/misc/lc3-tm4c/Cargo.toml
+++ b/misc/lc3-tm4c/Cargo.toml
@@ -3,6 +3,7 @@ name = "lc3-tm4c"
 version = "0.1.0"
 authors = ["UT UTP <ut.utp.group@gmail.com>"]
 edition = "2018"
+publish = false
 default-run = "lc3-tm4c"
 
 # TODO: CI

--- a/misc/lc3-tm4c/Cargo.toml
+++ b/misc/lc3-tm4c/Cargo.toml
@@ -27,9 +27,9 @@ panic-semihosting = "0.5.3"
 # tm4c123x-hal = { version = "0.10.0", features = ["rt"] }
 tm4c123x-hal = { git = "https://github.com/thejpster/tm4c-hal/", features = ["rt"] }
 
-lc3-baseline-sim = { path = "../../baseline-sim", version = "0.1.0", default-features = false, features = ["no_std"] }
-lc3-isa = { path = "../../isa", version = "0.1.0", default-features = false, features = ["no_std"] }
-lc3-traits = { path = "../../traits", version = "0.1.0", default-features = false, features = ["no_std"]  }
+lc3-baseline-sim = { path = "../../baseline-sim", version = "0.1.0" }
+lc3-isa = { path = "../../isa", version = "0.1.0" }
+lc3-traits = { path = "../../traits", version = "0.1.0"  }
 
 [[bin]]
 name = "hc05-at"

--- a/misc/serial/Cargo.toml
+++ b/misc/serial/Cargo.toml
@@ -3,6 +3,7 @@ name = "serial"
 version = "0.1.0"
 authors = ["Rahul Butani <rr.butani@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/os/Cargo.toml
+++ b/os/Cargo.toml
@@ -49,3 +49,9 @@ path = "tests/trap_tests/mod.rs"
 [features]
 default = []
 nightly-const = ["lc3-isa/nightly-const"] # Requires nightly; isn't tested by CI.
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/os/src/lib.rs
+++ b/os/src/lib.rs
@@ -45,6 +45,9 @@
 
 #![deny(intra_doc_link_resolution_failure)] // TODO: this is temporary
 
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
+
 // We're a no_std crate!
 #![no_std]
 
@@ -77,9 +80,6 @@ pub const ERROR_ON_ACV_SETTING_ADDR: lc3_isa::Addr = 0x0601;
 pub const OS_STARTING_SP_ADDR: lc3_isa::Addr = 0x0602;
 
 pub const OS_DEFAULT_STARTING_SP: lc3_isa::Word = 0x0700;
-
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
 
 mod os;
 

--- a/os/src/lib.rs
+++ b/os/src/lib.rs
@@ -55,19 +55,10 @@
 // this is fine for now.
 #![cfg_attr(feature = "nightly-const", feature(const_if_match))]
 #![cfg_attr(feature = "nightly-const", feature(const_panic))]
-#![cfg_attr(feature = "nightly-const", feature(const_fn))]
 
 // Makes some an item const if the nightly-const feature is activated and not
 // const otherwise.
-macro_rules! nightly_const {
-    ([$($vis:tt)*] => [$($rest:tt)*]) => (
-        #[cfg(not(feature = "nightly-const"))]
-        $($vis)* $($rest)*
-
-        #[cfg(feature = "nightly-const")]
-        $($vis)* const $($rest)*
-    );
-}
+use lc3_isa::nightly_const;
 
 extern crate static_assertions as sa;
 

--- a/os/src/os.rs
+++ b/os/src/os.rs
@@ -22,10 +22,11 @@ lazy_static! {
     pub static ref OS: AssembledProgram = os();
 }
 
+#[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "nightly-const")))]
 #[cfg(feature = "nightly-const")]
 pub const CONST_OS: AssembledProgram = os();
 
-nightly_const! { [] => [
+crate::nightly_const! { [] => [
 fn os() -> AssembledProgram {
     use Word as W;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.62.0"
+components = [ "rustc", "cargo", "rustfmt", "rust-std", "rust-docs", "clippy", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/shims/Cargo.toml
+++ b/shims/Cargo.toml
@@ -42,3 +42,9 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 lc3-test-infrastructure = { path = "../test-infrastructure", version = "0.1.0" }
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/shims/Cargo.toml
+++ b/shims/Cargo.toml
@@ -30,7 +30,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 lc3-isa = { path = "../isa", version = "0.1.0", default-features = false }
 lc3-macros = { path = "../macros", version = "0.1.0" }
-lc3-traits = { path = "../traits", version = "0.1.0", default-features = false }
+lc3-traits = { path = "../traits", version = "0.1.0", features = ["std"] }
 
 byteorder = "1.3.2"
 timer = "0.2.0"

--- a/shims/src/lib.rs
+++ b/shims/src/lib.rs
@@ -51,7 +51,11 @@ extern crate static_assertions as sa;
 #[macro_export]
 macro_rules! not_wasm {
     ($($i:item)*) => {
-        $( #[cfg(not(target_arch = "wasm32"))] $i )*
+        $(
+            #[cfg_attr(all(docs, not(doctest)), doc(cfg(not(target_arch = "wasm32"))))]
+            #[cfg(not(target_arch = "wasm32"))]
+            $i
+        )*
     };
 }
 
@@ -59,7 +63,11 @@ macro_rules! not_wasm {
 #[macro_export]
 macro_rules! wasm {
     ($($i:item)*) => {
-        $( #[cfg(target_arch = "wasm32")] $i )*
+        $(
+            #[cfg_attr(all(docs, not(doctest)), doc(cfg(target_arch = "wasm32")))]
+            #[cfg(target_arch = "wasm32")]
+            $i
+        )*
     };
 }
 

--- a/shims/src/lib.rs
+++ b/shims/src/lib.rs
@@ -42,6 +42,9 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
+
 extern crate static_assertions as sa;
 
 #[doc(hidden)]

--- a/test-infrastructure/Cargo.toml
+++ b/test-infrastructure/Cargo.toml
@@ -40,5 +40,3 @@ pretty_assertions = "0.6.1"
 
 
 [features]
-
-

--- a/test-infrastructure/src/lib.rs
+++ b/test-infrastructure/src/lib.rs
@@ -68,6 +68,7 @@ mod runner;
 mod misc;
 
 // The bash script will not work on Windows.
+#[cfg_attr(all(docs, not(doctest)), doc(cfg(target_family = "unix")))]
 #[cfg(target_family = "unix")]
 #[macro_use] pub mod lc3tools;
 

--- a/test-infrastructure/src/lib.rs
+++ b/test-infrastructure/src/lib.rs
@@ -39,6 +39,8 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 #[doc(no_inline)]
 pub use {

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -41,8 +41,9 @@ pretty_assertions = "0.6.1"
 
 
 [features]
-no_std = ["lc3-isa/no_std"]
-json_encoding_layer = ["serde_json"]
+default = []
+std = ["lc3-isa/std"]
+json_encoding_layer = ["std", "serde_json"]
 
 [package.metadata.docs.rs]
 # targets = [""]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -43,3 +43,9 @@ pretty_assertions = "0.6.1"
 [features]
 no_std = ["lc3-isa/no_std"]
 json_encoding_layer = ["serde_json"]
+
+[package.metadata.docs.rs]
+# targets = [""]
+rustdoc-args = ["--cfg", "docs"]
+all-features = true
+# default-target = ""

--- a/traits/src/control/rpc/encoding.rs
+++ b/traits/src/control/rpc/encoding.rs
@@ -958,10 +958,12 @@ where
 using_std! {
     use serde::{Serialize, de::DeserializeOwned};
 
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "json_encoding_layer")))]
     #[cfg(feature = "json_encoding_layer")]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
     pub struct JsonEncoding;
 
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "json_encoding_layer")))]
     #[cfg(feature = "json_encoding_layer")]
     impl<Message: Debug + Serialize> Encode<Message> for JsonEncoding {
         type Encoded = String;
@@ -971,6 +973,7 @@ using_std! {
         }
     }
 
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "json_encoding_layer")))]
     #[cfg(feature = "json_encoding_layer")]
     impl<Message: Debug + DeserializeOwned> Decode<Message> for JsonEncoding {
         type Encoded = String;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -42,16 +42,13 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(html_logo_url = "")] // TODO!
 
-// Mark the crate as no_std if the `no_std` feature is enabled.
-#![cfg_attr(all(feature = "no_std", not(test)), no_std)]
+// Enable the `doc_cfg` feature when running rustdoc.
+#![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
 macro_rules! using_std { ($($i:item)*) => ($(#[cfg(not(feature = "no_std"))]$i)*) }
 
 macro_rules! not_wasm { ($($i:item)*) => ($(#[cfg(not(target_arch = "wasm32"))]$i)*) }
 macro_rules! wasm { ($($i:item)*) => ($(#[cfg(target_arch = "wasm32")]$i)*) }
-
-#[allow(unused_extern_crates)]
-extern crate core; // makes rls actually look into the standard library (hack)
 
 extern crate static_assertions as sa;
 

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -49,6 +49,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 macro_rules! using_std { ($($i:item)*) => ($(
+    #[cfg_attr(all(docs, not(doctest)), doc(cfg(feature = "std")))]
     #[cfg(feature = "std")]
     $i
 )*) }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -45,7 +45,13 @@
 // Enable the `doc_cfg` feature when running rustdoc.
 #![cfg_attr(all(docs, not(doctest)), feature(doc_cfg))]
 
-macro_rules! using_std { ($($i:item)*) => ($(#[cfg(not(feature = "no_std"))]$i)*) }
+// Mark the crate as no_std if the `std` feature **not** is enabled.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+macro_rules! using_std { ($($i:item)*) => ($(
+    #[cfg(feature = "std")]
+    $i
+)*) }
 
 macro_rules! not_wasm { ($($i:item)*) => ($(#[cfg(not(target_arch = "wasm32"))]$i)*) }
 macro_rules! wasm { ($($i:item)*) => ($(#[cfg(target_arch = "wasm32")]$i)*) }


### PR DESCRIPTION
Mostly no functional changes here; just some build improvements having to do with things we've learned how to do better since 2020.

The commits are self-contained and do a decent job explaining what's going on; the main changes are:
  - adding a nix flake to the project (to match `tm4c` and `tui`)
    + it's not as big of a help here as it is in those other projects since we don't have much in the way of dependencies but the consistency is nice
    + as we discover deps that aren't already covered (i.e. `cmake`, `pkg-config` for `lc3tools-sys`) I expect we'll add to this
  - adding infra for [`doc_cfg`](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html) support and adding uses throughout the project
  - cleaning up the features a bit (`std` instead of `no_std`, etc.)